### PR TITLE
fix: skip two tests temporary due to changed project config

### DIFF
--- a/tests/Integration/CredentialIssuanceClientIntegrationTest.php
+++ b/tests/Integration/CredentialIssuanceClientIntegrationTest.php
@@ -7,6 +7,8 @@ class CredentialIssuanceClientIntegrationTest extends TestCase
 {
     public function testIssuance()
     {
+        $this->markTestSkipped('Enable as soon as dedicated project + configuration has been created.');
+
         $config = CredentialIssuanceClient\Configuration::getDefaultConfiguration()->setApiKey('authorization', '', getTokenCallback());
 
         $api = new CredentialIssuanceClient\Api\IssuanceApi(

--- a/tests/Integration/IotaClientIntegrationTest.php
+++ b/tests/Integration/IotaClientIntegrationTest.php
@@ -33,6 +33,8 @@ class IotaClientIntegrationTest extends TestCase
 
     public function testRedirectFlow()
     {
+        $this->markTestSkipped('Enable as soon as dedicated project + configuration has been created.');
+
         $config = IotaClient\Configuration::getDefaultConfiguration()->setApiKey('authorization', '', getTokenCallback());
         $configCallback = IotaClient\Configuration::getDefaultConfiguration();
 


### PR DESCRIPTION
project configuration has changed and does not match values in env configuration:

* failing iota test: wallet seems to not exist anymore
* failing cis test: credentialTypeId does not exist anymore
